### PR TITLE
Avoiding access to uninitialized variable

### DIFF
--- a/ProcessSlicedLayersJob.py
+++ b/ProcessSlicedLayersJob.py
@@ -79,6 +79,8 @@ class ProcessSlicedLayersJob(Job):
     def run(self):
         Logger.log("d", "Processing new layer for build plate %s..." % self._build_plate_number)
         start_time = time()
+        last_point_hit_wall = False
+  
         view = Application.getInstance().getController().getActiveView()
         if view.getPluginId() == "SimulationView":
             view.resetLayerData()


### PR DESCRIPTION
In line 194 the variable last_point_hit_wall could be accessed without being previously initialized. 
It looks safer for me to inizialize it at false at the beginning of the run loop